### PR TITLE
Add ModOptionsAPI

### DIFF
--- a/Contents/mods/!pz_frameworks/42/media/lua/client/ModOptionsAPI.lua
+++ b/Contents/mods/!pz_frameworks/42/media/lua/client/ModOptionsAPI.lua
@@ -1,0 +1,114 @@
+-- A small API to make working with the new B42 ModOptions easier.
+local ModOptionsAPI = {
+    opts = {}
+}
+
+-- Sync Sandbox options with our ModOptions, if enabled
+local syncOptions = function(self)
+    if self._sandbox and SandboxVars[self._sandbox] then
+        local vars = SandboxVars[self._sandbox]
+        for k,v in pairs(vars) do
+            self[k] = v
+        end
+    end
+end
+
+-- Generic function to add all of our options to our object
+--- An "Apply()" function is available while in game.
+local applyOptions = function(self, initLoad)
+    for k,v in pairs(self.dict) do
+        if v.type == "multipletickbox" then
+            for i=1, #v.values do
+                k = (k.."_"..tostring(i))
+                self[k] = v:getValue(i)
+            end
+        elseif v.type ~= "button" then
+            self[k] = v:getValue()
+        end
+    end
+    if MainScreen.instance.inGame then
+        self:sync()
+        self:Apply()
+    elseif initLoad then
+        self:sync()
+    end
+end
+
+-- Local build function
+local build = function()
+    for i=1, #ModOptionsAPI.opts do
+        local opt = ModOptionsAPI.opts[i]
+        opt:Build()
+        if opt.sync then
+            if not opt._sync then
+                opt._sync = function()
+                    opt:apply(true)
+                end
+            end
+            if Events.OnSandboxOptionsChanged then
+                Events.OnSandboxOptionsChanged.Add(opt._sync)
+            end
+            Events.OnInitGlobalModData.Add(opt._sync)
+        end
+    end
+    -- We don't need to hold on to these anymore, so let's clean up
+    for i=#ModOptionsAPI.opts, 1, -1 do
+        ModOptionsAPI.opts[i] = nil
+    end
+    ModOptionsAPI.opts = nil
+end
+
+-- Set our build function to run OnGameBoot, ensure "reloads" are handled.
+Events.OnGameBoot.Remove(build)
+Events.OnGameBoot.Add(build)
+
+-- Create a new ModOptionsAPI object
+---- `ID` - Should be a UNIQUE ModOptions ID
+---- `name` - The name for your options, will be displayed.
+---- `sandbox` - An optional parameter to sync your Sandbox namespace.
+--- @param ID string
+--- @param name string
+--- @param sandbox string?
+--- @return table
+function ModOptionsAPI:new(ID, name, sandbox)
+    local options = PZAPI.ModOptions:create(ID, name)
+    options.apply = applyOptions
+    options.sync = function(self) end
+    
+    options._sandbox = sandbox
+    if options._sandbox then
+        options.sync = syncOptions
+    end
+    options.Build = function(self) end
+    options.Apply = function(self) end
+    self.opts[#self.opts+1] = options
+    return options
+end
+
+return ModOptionsAPI
+
+---------------------
+---- Example:
+--- For a full example, see: "B42 Native ModOptions Example" on the Workshop
+---- https://steamcommunity.com/sharedfiles/filedetails/?id=3386860561
+---------------------
+--- In a new file, add the following:
+---- local options = require("ModOptionsAPI"):new("UNIQUEID", "OPTIONSNAME", "SANDBOX")
+---
+---- function options:Build()
+---- ---- Build your ModOptions here using the standard ModOptions functions
+---- end
+---
+---- function options:Apply()
+---- ---- Perform any additional actions in game based on changed settings. Only run in game.
+---- end
+
+---- return options
+---------------------
+--- In your mod, include your module:
+---- local options = require("MyConfig")
+---
+--- Now you can call your options as such:
+---- options.ID
+--- Where "ID" is the ID you set when creating each option.
+---------------------


### PR DESCRIPTION
This is an API that I created to help facilitate new ModOptions in the new system. 
While the new system is easy to use, it can be simpler!

### **Features:**
- Easy ModOptions creation using the new B42 native ModOptions
- Automatic value population for easy access to the options you created, named by the ID.
- Intended to be used as a module by your own mod to support good habits.
- (Optional) Sandbox sync support

**NOTE:** Options are not guaranteed populated until event "OnInitGlobalModData", which is called when starting an actual game. 

---
### **Usage:**
If this is accepted, I will also update my B42 ModOptions example on the Workshop to include an example as well.

In a new file in your mod (we'll name it "MyConfig.lua"), add the following:
```lua
local config = require("ModOptionsAPI"):new("UNIQUEID", "NAME")

function config:Build()
   -- These are just examples
    self:addKeyBind("keybind", "KeyBind", Keyboard.KEY_Z)
   -- Either "self" or "config" can be used
    config:addTickBox("tickbox", "Check Box", false, "A basic tooltip")
end

function config:Apply()
    -- Optional, can remove if unneeded. An exposed function that is called when options are changed in game.
end

return config
```

The `Build()` function is required, and will be called by the ModOptionsAPI "OnGameBoot" to populate the available options set by your mod. 

The `Apply()` function is optional, and can be removed from the file if it is not needed. However, you can use this to run things while you are in game to accommodate for the option changes.

In your mod, add the following:
```lua
local options = require("MyConfig")
```

Now you can directly access any of your options with simply:
```lua
options."ID"
```
Where "ID" is the ID that you specified when creating each option.  Using the above example:
```lua
local key = options.keybind
local tick = options.tickbox
```

Multi-checkbox options are unique, in that the `getValue` function also requires the index. When parsing the options for these, I opted to append the index to the end of the ID you created. 

Given:
```lua
function config:Build()
    local multibox = self:addMultipleTickBox("multibox", "Multibox")
    multibox:addTickBox("Option A", false)
    multibox:addTickBox("Option B", true)
end
```
These would be available as:
```lua
local options = require("MyConfig")
local optionA = options.multibox_1
local optionB = options.multibox_2
```
---
### **Sandbox**
For Sandbox variable support, add the Sandbox namespace to end end of the ":new()" function:
```lua
local config = require("ModOptionsAPI"):new("UNIQUEID", "NAME", "SANDBOX")
```

Any Sandbox options are now available in our `config` table when in-game automatically.

For example, given:
```
option B42ModOptions.TestValue 
{
    type = integer, min = 0, max = 100, default = 3,
    page = B42ModOptions, translation = B42ModOptions_TestValue,
}
```
The namespace in the above is "B42ModOptions".

This will be available in game as:
```lua 
local options = require("MyConfig")
local value = options.TestValue
```

Supports the `OnSandboxOptionsChanged` created by [Change Sandbox Options (by Star)](https://steamcommunity.com/sharedfiles/filedetails/?id=2894296454), so a change in Sandbox Options in Single Player is propagated immediately.  The `Apply()` function is called in these cases as well.